### PR TITLE
Add shared DynamoDB solver cache for instant hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -173,7 +173,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Abstra
 # Abstra is an AI-powered process automation framework.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,4 +34,4 @@ USER appuser
 EXPOSE 5000
 
 # Run the app using gunicorn with single worker to avoid session sharing issues
-CMD ["gunicorn", "-b", "0.0.0.0:5000", "--workers", "1", "--timeout", "120", "app:app"] 
+CMD ["gunicorn", "-b", "0.0.0.0:5000", "--workers", "1", "--threads", "4", "--timeout", "120", "app:app"] 

--- a/prepopulate_cache.py
+++ b/prepopulate_cache.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Pre-populate the solver cache by solving each level configuration and
+caching every intermediate state along the solution path.
+
+Usage:
+    python3 prepopulate_cache.py                  # solve all levels
+    python3 prepopulate_cache.py --levels 1,2,3   # specific levels only
+    python3 prepopulate_cache.py --time-limit 300  # generous timeout
+    python3 prepopulate_cache.py --dry-run         # solve but don't write
+"""
+
+import argparse
+import time
+
+from solver import solve, _board_to_bits
+from solver_cache import solver_cache, _apply_move_to_bits
+
+# Level configurations (mirrored from app.py)
+LEVEL_CONFIGS = {
+    1: {
+        'name': 'Level 1 - Cross',
+        'marbles': [
+            (4, 2), (4, 3), (4, 4), (4, 5), (4, 6),
+            (2, 4), (3, 4), (5, 4), (6, 4),
+        ],
+    },
+    2: {
+        'name': 'Level 2 - Small triangle',
+        'marbles': [
+            (2, 4),
+            (3, 3), (3, 4), (3, 5),
+            (4, 2), (4, 3), (4, 4), (4, 5), (4, 6),
+            (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7),
+        ],
+    },
+    3: {
+        'name': 'Level 3 - Arrow',
+        'marbles': [
+            (1, 4),
+            (2, 3), (2, 4), (2, 5),
+            (3, 2), (3, 3), (3, 4), (3, 5), (3, 6),
+            (4, 4),
+            (5, 4),
+            (6, 3), (6, 4), (6, 5),
+            (7, 3), (7, 4), (7, 5),
+        ],
+    },
+    4: {
+        'name': 'Level 4 - Diamond',
+        'marbles': [
+            (1, 4),
+            (2, 3), (2, 4), (2, 5),
+            (3, 2), (3, 3), (3, 4), (3, 5), (3, 6),
+            (4, 1), (4, 2), (4, 3), (4, 5), (4, 6), (4, 7),
+            (5, 2), (5, 3), (5, 4), (5, 5), (5, 6),
+            (6, 3), (6, 4), (6, 5),
+            (7, 4),
+        ],
+    },
+    5: {
+        'name': 'Level 5 - Big triangle',
+        'marbles': [
+            (1, 4),
+            (2, 3), (2, 4), (2, 5),
+            (3, 2), (3, 3), (3, 4), (3, 5), (3, 6),
+            (4, 1), (4, 2), (4, 3), (4, 4), (4, 5), (4, 6), (4, 7),
+            (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7), (5, 8),
+        ],
+    },
+    6: {
+        'name': 'Level 6 - Small square',
+        'marbles': [
+            (1, 3), (1, 4), (1, 5),
+            (2, 3), (2, 4), (2, 5),
+            (3, 1), (3, 2), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7),
+            (4, 1), (4, 2), (4, 3), (4, 5), (4, 6), (4, 7),
+            (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7),
+            (6, 3), (6, 4), (6, 5),
+            (7, 3), (7, 4), (7, 5),
+        ],
+    },
+    7: {
+        'name': 'Level 7 - Full board',
+        'marbles': [
+            (0, 3), (0, 4), (0, 5),
+            (1, 3), (1, 4), (1, 5),
+            (2, 3), (2, 4), (2, 5),
+            (3, 0), (3, 1), (3, 2), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (3, 8),
+            (4, 0), (4, 1), (4, 2), (4, 3), (4, 5), (4, 6), (4, 7), (4, 8),
+            (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7), (5, 8),
+            (6, 3), (6, 4), (6, 5),
+            (7, 3), (7, 4), (7, 5),
+            (8, 3), (8, 4), (8, 5),
+        ],
+    },
+}
+
+
+def build_board(marbles):
+    """Build a 9x9 boolean board from a list of (row, col) marble positions."""
+    board = [[False] * 9 for _ in range(9)]
+    for r, c in marbles:
+        board[r][c] = True
+    return board
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Pre-populate solver cache')
+    parser.add_argument('--levels', type=str, default=None,
+                        help='Comma-separated level numbers (default: all)')
+    parser.add_argument('--time-limit', type=int, default=300,
+                        help='Seconds per level (default: 300)')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Solve but do not write to DynamoDB')
+    args = parser.parse_args()
+
+    if args.levels:
+        levels = [int(x) for x in args.levels.split(',')]
+    else:
+        levels = list(LEVEL_CONFIGS.keys())
+
+    if not args.dry_run:
+        print("Initializing solver cache table...")
+        solver_cache.create_table_if_not_exists()
+
+    for level_num in levels:
+        config = LEVEL_CONFIGS[level_num]
+        name = config['name']
+        marbles = config['marbles']
+        stone_count = len(marbles)
+
+        print(f"\n{'='*50}")
+        print(f"{name}  ({stone_count} stones)")
+        print(f"{'='*50}")
+
+        board = build_board(marbles)
+        bits = _board_to_bits(board)
+
+        # Skip if already cached
+        if not args.dry_run:
+            cached = solver_cache.get_solution(bits)
+            if cached:
+                print(f"  Already cached ({len(cached)} moves) — skipping")
+                continue
+
+        start = time.monotonic()
+        solution = solve(board, time_limit=args.time_limit)
+        elapsed = time.monotonic() - start
+
+        if solution is None:
+            print(f"  FAILED - no solution found in {elapsed:.1f}s")
+            continue
+
+        states_count = len(solution)
+        print(f"  Solved in {elapsed:.1f}s  ({states_count} moves, {states_count} intermediate states)")
+
+        if args.dry_run:
+            print("  (dry-run) Skipping cache write")
+        else:
+            solver_cache.cache_solution_path(bits, solution, stone_count)
+            print(f"  Cached {states_count} states")
+
+    print(f"\n{'='*50}")
+    print("Done.")
+
+
+if __name__ == '__main__':
+    main()

--- a/templates/skipping_stones.html
+++ b/templates/skipping_stones.html
@@ -698,8 +698,12 @@ class SkippingStonesGame {
         // Check if current level is completed and show/hide share button accordingly
         this.checkGameStatus();
 
-        // Update hint if enabled
-        if (this.hintsEnabled) this.fetchHint();
+        // Turn off hints on level switch
+        if (this.hintsEnabled) {
+            this.hintsEnabled = false;
+            this.clearHint();
+            this.updateHintButtonState();
+        }
 
         // Update user stats
         this.updateUserStats();
@@ -749,8 +753,12 @@ class SkippingStonesGame {
         console.log('Saving level state for current level after config load...');
         this.saveLevelState();
 
-        // Update hint if enabled
-        if (this.hintsEnabled) this.fetchHint();
+        // Turn off hints on config load
+        if (this.hintsEnabled) {
+            this.hintsEnabled = false;
+            this.clearHint();
+            this.updateHintButtonState();
+        }
 
         // Update user stats
         this.updateUserStats();
@@ -904,8 +912,12 @@ class SkippingStonesGame {
         console.log('Saving level state for current level...');
         this.saveLevelState();
 
-        // Update hint if enabled
-        if (this.hintsEnabled) this.fetchHint();
+        // Turn off hints after each move
+        if (this.hintsEnabled) {
+            this.hintsEnabled = false;
+            this.clearHint();
+            this.updateHintButtonState();
+        }
 
         // Update user stats
         this.updateUserStats();
@@ -1031,8 +1043,12 @@ class SkippingStonesGame {
         // Hide share button when game is reset
         this.hideShareButton();
 
-        // Update hint if enabled
-        if (this.hintsEnabled) this.fetchHint();
+        // Turn off hints on reset
+        if (this.hintsEnabled) {
+            this.hintsEnabled = false;
+            this.clearHint();
+            this.updateHintButtonState();
+        }
 
         // Update user stats
         this.updateUserStats();
@@ -1068,8 +1084,12 @@ class SkippingStonesGame {
         console.log('Saving level state for current level after undo...');
         this.saveLevelState();
 
-        // Update hint if enabled
-        if (this.hintsEnabled) this.fetchHint();
+        // Turn off hints on undo
+        if (this.hintsEnabled) {
+            this.hintsEnabled = false;
+            this.clearHint();
+            this.updateHintButtonState();
+        }
 
         // Update user stats
         this.updateUserStats();

--- a/templates/skipping_stones.html
+++ b/templates/skipping_stones.html
@@ -31,7 +31,7 @@
                                 <i class="fas fa-undo me-2"></i>Undo
                             </button>
                             <button id="hintBtn" class="btn btn-outline-info">
-                                <i class="fas fa-lightbulb me-2"></i>Hints
+                                <i class="fas fa-lightbulb me-2"></i>Hint
                             </button>
                         </div>
                     </div>
@@ -700,9 +700,7 @@ class SkippingStonesGame {
 
         // Turn off hints on level switch
         if (this.hintsEnabled) {
-            this.hintsEnabled = false;
-            this.clearHint();
-            this.updateHintButtonState();
+            this.cancelHintSolving();
         }
 
         // Update user stats
@@ -755,9 +753,7 @@ class SkippingStonesGame {
 
         // Turn off hints on config load
         if (this.hintsEnabled) {
-            this.hintsEnabled = false;
-            this.clearHint();
-            this.updateHintButtonState();
+            this.cancelHintSolving();
         }
 
         // Update user stats
@@ -914,9 +910,7 @@ class SkippingStonesGame {
 
         // Turn off hints after each move
         if (this.hintsEnabled) {
-            this.hintsEnabled = false;
-            this.clearHint();
-            this.updateHintButtonState();
+            this.cancelHintSolving();
         }
 
         // Update user stats
@@ -1045,9 +1039,7 @@ class SkippingStonesGame {
 
         // Turn off hints on reset
         if (this.hintsEnabled) {
-            this.hintsEnabled = false;
-            this.clearHint();
-            this.updateHintButtonState();
+            this.cancelHintSolving();
         }
 
         // Update user stats
@@ -1086,9 +1078,7 @@ class SkippingStonesGame {
 
         // Turn off hints on undo
         if (this.hintsEnabled) {
-            this.hintsEnabled = false;
-            this.clearHint();
-            this.updateHintButtonState();
+            this.cancelHintSolving();
         }
 
         // Update user stats
@@ -1643,14 +1633,22 @@ class SkippingStonesGame {
     }
     
     toggleHints() {
-        this.hintsEnabled = !this.hintsEnabled;
-        this.updateHintButtonState();
         if (this.hintsEnabled) {
-            this.fetchHint();
-        } else {
-            this.clearHint();
+            this.cancelHintSolving();
             this.renderBoard();
+        } else {
+            this.hintsEnabled = true;
+            this.updateHintButtonState();
+            this.fetchHint();
         }
+    }
+
+    cancelHintSolving() {
+        this.hintsEnabled = false;
+        this.hintRequestId++;
+        document.getElementById('hintBtn').innerHTML = '<i class="fas fa-lightbulb me-2"></i>Hint';
+        this.clearHint();
+        this.updateHintButtonState();
     }
 
     updateHintButtonState() {
@@ -1667,28 +1665,69 @@ class SkippingStonesGame {
     async fetchHint() {
         if (!this.hintsEnabled) return;
         const requestId = ++this.hintRequestId;
+        const hintBtn = document.getElementById('hintBtn');
+
         try {
+            hintBtn.innerHTML = '<i class="fas fa-spinner fa-spin me-2"></i>Solving...';
+
             const response = await fetch('/api/skipping-stones/hint', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ board: this.board })
             });
-            if (requestId !== this.hintRequestId) return; // stale response
-            if (response.ok) {
-                const data = await response.json();
-                this.currentHint = data.hint;
-                if (this.currentHint) {
-                    this.selectedMarble = { row: this.currentHint.from_row, col: this.currentHint.from_col };
-                }
-            } else {
+            if (requestId !== this.hintRequestId) return;
+            if (!response.ok) {
                 this.currentHint = null;
+                return;
+            }
+
+            const reader = response.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (requestId !== this.hintRequestId) return;
+                if (done) break;
+
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split('\n');
+                buffer = lines.pop(); // keep incomplete line in buffer
+
+                for (const line of lines) {
+                    if (!line.trim()) continue;
+                    const msg = JSON.parse(line);
+                    if (msg.type === 'progress') {
+                        const elapsed = Math.floor(msg.elapsed);
+                        hintBtn.innerHTML = `<i class="fas fa-spinner fa-spin me-2"></i>Solving... ${elapsed}s`;
+                    } else if (msg.type === 'result') {
+                        this.currentHint = msg.hint;
+                        if (this.currentHint) {
+                            this.selectedMarble = { row: this.currentHint.from_row, col: this.currentHint.from_col };
+                        } else {
+                            this.hintsEnabled = false;
+                            this.updateHintButtonState();
+                            if (msg.timed_out) {
+                                this.showHintNotification('Solver timed out.', 'warning');
+                            } else {
+                                this.showHintNotification('No solution found from this position.', 'info');
+                            }
+                        }
+                    }
+                }
             }
         } catch (error) {
             if (requestId !== this.hintRequestId) return;
             console.error('Error fetching hint:', error);
             this.currentHint = null;
+        } finally {
+            if (requestId === this.hintRequestId) {
+                if (this.hintsEnabled) {
+                    hintBtn.innerHTML = '<i class="fas fa-lightbulb me-2"></i>Hint';
+                }
+                this.renderBoard();
+            }
         }
-        this.renderBoard();
     }
 
     clearHint() {
@@ -1698,6 +1737,22 @@ class SkippingStonesGame {
             this.selectedMarble = null;
         }
         this.currentHint = null;
+    }
+
+    showHintNotification(message, type) {
+        const existing = document.getElementById('hintNotification');
+        if (existing) existing.remove();
+
+        const alert = document.createElement('div');
+        alert.id = 'hintNotification';
+        alert.className = `alert alert-${type} alert-dismissible fade show mt-2 mb-0 py-2 px-3`;
+        alert.style.fontSize = '0.85em';
+        alert.innerHTML = `${message}<button type="button" class="btn-close btn-close-sm" data-bs-dismiss="alert"></button>`;
+
+        const hintBtn = document.getElementById('hintBtn');
+        hintBtn.parentNode.insertBefore(alert, hintBtn.nextSibling);
+
+        setTimeout(() => { if (alert.parentNode) alert.remove(); }, 5000);
     }
 
     getGameStatus() {

--- a/tests/test_solver_cache.py
+++ b/tests/test_solver_cache.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Tests for the solver cache module.
+
+Validates bitmask transformations and solution-path decomposition without
+requiring a live DynamoDB connection.
+"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from solver import _board_to_bits, _CELL_INDEX, VALID_CELLS, solve
+from solver_cache import _apply_move_to_bits
+
+
+def _make_board(marbles):
+    """Build a 9x9 boolean board from a list of (row, col) positions."""
+    board = [[False] * 9 for _ in range(9)]
+    for r, c in marbles:
+        board[r][c] = True
+    return board
+
+
+def test_apply_move_to_bits():
+    """Verify _apply_move_to_bits matches manual board-level transformation."""
+    # Set up a simple board: stones at (4,2), (4,3), (4,4) with (4,4) empty target
+    marbles = [(4, 2), (4, 3), (4, 4)]
+    board = _make_board(marbles)
+    bits_before = _board_to_bits(board)
+
+    # Move: (4,2) jumps over (4,3) to land on (4,4)... wait, (4,4) has a stone.
+    # Instead: stone at (4,2) jumps over (4,3) landing at (4,4) — but (4,4) is occupied.
+    # Let's use: stones at (4,2), (4,3), empty at (4,4)
+    marbles = [(4, 2), (4, 3)]
+    board = _make_board(marbles)
+    bits_before = _board_to_bits(board)
+
+    move = {
+        'from_row': 4, 'from_col': 2,
+        'to_row': 4, 'to_col': 4,
+        'jump_row': 4, 'jump_col': 3,
+    }
+
+    bits_after = _apply_move_to_bits(bits_before, move)
+
+    # After the move: (4,2) gone, (4,3) gone, (4,4) present
+    expected_board = _make_board([(4, 4)])
+    expected_bits = _board_to_bits(expected_board)
+
+    assert bits_after == expected_bits, (
+        f"Bitmask mismatch: got {bits_after}, expected {expected_bits}"
+    )
+    print("  PASS test_apply_move_to_bits")
+
+
+def test_apply_move_preserves_other_stones():
+    """Verify that _apply_move_to_bits does not disturb unrelated stones."""
+    marbles = [(0, 3), (4, 2), (4, 3), (8, 5)]
+    board = _make_board(marbles)
+    bits_before = _board_to_bits(board)
+
+    move = {
+        'from_row': 4, 'from_col': 2,
+        'to_row': 4, 'to_col': 4,
+        'jump_row': 4, 'jump_col': 3,
+    }
+
+    bits_after = _apply_move_to_bits(bits_before, move)
+
+    expected_board = _make_board([(0, 3), (4, 4), (8, 5)])
+    expected_bits = _board_to_bits(expected_board)
+
+    assert bits_after == expected_bits, (
+        f"Bitmask mismatch: got {bits_after}, expected {expected_bits}"
+    )
+    print("  PASS test_apply_move_preserves_other_stones")
+
+
+def test_cache_solution_path_decomposition():
+    """Verify all intermediate states are correctly derived from a solution.
+
+    Uses the level-1 solver to get a real solution, then walks through it
+    with _apply_move_to_bits and verifies each successive state.
+    """
+    # Level 1 - Cross
+    marbles = [
+        (4, 2), (4, 3), (4, 4), (4, 5), (4, 6),
+        (2, 4), (3, 4), (5, 4), (6, 4),
+    ]
+    board = _make_board(marbles)
+    solution = solve(board, time_limit=10)
+    assert solution is not None, "Level 1 should be solvable"
+
+    bits = _board_to_bits(board)
+    stone_count = len(marbles)
+
+    # Walk the solution and verify each intermediate state
+    for i, move in enumerate(solution):
+        # The remaining moves from this state should be solution[i:]
+        remaining = solution[i:]
+        assert len(remaining) == len(solution) - i
+
+        next_bits = _apply_move_to_bits(bits, move)
+
+        # Verify the stone count decreases by 1
+        next_stone_count = bin(next_bits).count('1')
+        assert next_stone_count == stone_count - 1, (
+            f"Step {i}: expected {stone_count - 1} stones, got {next_stone_count}"
+        )
+
+        bits = next_bits
+        stone_count = next_stone_count
+
+    # Final state should have exactly 1 stone
+    assert stone_count == 1, f"Expected 1 stone at end, got {stone_count}"
+    print("  PASS test_cache_solution_path_decomposition")
+
+
+def test_roundtrip_state_consistency():
+    """Verify that applying all moves in sequence produces a 1-stone state."""
+    # Level 2 - Small triangle
+    marbles = [
+        (2, 4),
+        (3, 3), (3, 4), (3, 5),
+        (4, 2), (4, 3), (4, 4), (4, 5), (4, 6),
+        (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7),
+    ]
+    board = _make_board(marbles)
+    solution = solve(board, time_limit=10)
+    assert solution is not None, "Level 2 should be solvable"
+
+    bits = _board_to_bits(board)
+    for move in solution:
+        bits = _apply_move_to_bits(bits, move)
+
+    final_stones = bin(bits).count('1')
+    assert final_stones == 1, f"Expected 1 stone after full solution, got {final_stones}"
+    print("  PASS test_roundtrip_state_consistency")
+
+
+if __name__ == '__main__':
+    print("Running solver cache tests...")
+    test_apply_move_to_bits()
+    test_apply_move_preserves_other_stones()
+    test_cache_solution_path_decomposition()
+    test_roundtrip_state_consistency()
+    print("\nAll solver cache tests passed!")


### PR DESCRIPTION
## Summary
- Add `solver_cache.py` with a DynamoDB-backed cache keyed by 45-bit board bitmask for instant hint lookups
- Integrate cache into the hint endpoint with write-through caching — cache misses are solved live and cached for all future users
- Add `prepopulate_cache.py` CLI script to pre-solve levels and cache every intermediate state along the solution path
- Add unit tests for bitmask transformations and solution path decomposition

## Test plan
- [x] `python3 run_tests.py` — all 4 test files pass (including new `test_solver_cache.py`)
- [x] `python3 prepopulate_cache.py --dry-run` — verify solving works without writing
- [x] `python3 prepopulate_cache.py` — populate the cache
- [x] Start app, enable hints, verify instant responses on cached levels
- [x] Make a non-optimal move, request hint — verify write-through caches the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)