### PR TITLE
Add background solve queue for timed-out hint requests

### DIFF
--- a/solve_queue.py
+++ b/solve_queue.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+CLI utility for solving queued board states from the solver queue.
+
+Usage:
+    python3 solve_queue.py           # solve one pending item
+    python3 solve_queue.py --all     # solve all pending items
+    python3 solve_queue.py --stats   # show queue statistics
+"""
+
+import argparse
+import time
+from solver import solve, _bits_to_board
+from solver_cache import solver_cache
+from solver_queue import solver_queue
+
+
+def show_stats():
+    stats = solver_queue.get_queue_stats()
+    print("Solver Queue Statistics")
+    print("-" * 30)
+    for status in ('pending', 'solving', 'solved', 'failed'):
+        print(f"  {status:>10}: {stats.get(status, 0)}")
+    print(f"  {'total':>10}: {stats.get('total', 0)}")
+
+
+def solve_one():
+    """Claim and solve a single pending item. Returns True if an item was processed."""
+    item = solver_queue.claim_next(include_solving=True)
+    if item is None:
+        print("No items in queue.")
+        return False
+
+    bits = int(item['board_state'])
+    sc = int(item['stone_count'])
+    board = _bits_to_board(bits)
+
+    print(f"Solving state {bits} ({sc} stones)...", flush=True)
+    start = time.monotonic()
+    solution = solve(board, time_limit=None)
+    elapsed = time.monotonic() - start
+
+    if solution is not None and len(solution) > 0:
+        solver_cache.cache_solution_path(bits, solution, sc)
+        solver_queue.mark_solved(bits)
+        print(f"  Solved in {elapsed:.1f}s — {len(solution)} moves cached.")
+    else:
+        solver_cache.put_no_solution(bits, sc)
+        solver_queue.mark_failed(bits)
+        print(f"  No solution exists ({elapsed:.1f}s). Negative-cached.")
+
+    return True
+
+
+def solve_all():
+    """Solve all pending items in the queue."""
+    count = 0
+    while True:
+        if not solve_one():
+            break
+        count += 1
+    print(f"\nProcessed {count} item(s).")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Solve queued board states.")
+    parser.add_argument('--all', action='store_true', help='Solve all pending items')
+    parser.add_argument('--stats', action='store_true', help='Show queue statistics')
+    parser.add_argument('--cleanup', action='store_true', help='Remove solved/failed items from queue')
+    args = parser.parse_args()
+
+    # Ensure tables exist
+    solver_cache.create_table_if_not_exists()
+    solver_queue.create_table_if_not_exists()
+
+    if args.cleanup:
+        count = solver_queue.cleanup_completed()
+        print(f"Removed {count} solved/failed item(s) from queue.")
+    elif args.stats:
+        show_stats()
+    elif args.all:
+        solve_all()
+    else:
+        solve_one()
+
+
+if __name__ == '__main__':
+    main()

--- a/solve_queue.py
+++ b/solve_queue.py
@@ -3,19 +3,100 @@
 CLI utility for solving queued board states from the solver queue.
 
 Usage:
-    python3 solve_queue.py           # solve one pending item
-    python3 solve_queue.py --all     # solve all pending items
-    python3 solve_queue.py --stats   # show queue statistics
+    python3 solve_queue.py                    # solve one pending item
+    python3 solve_queue.py --all              # solve all pending items
+    python3 solve_queue.py --all --workers 4  # solve all with 4 parallel workers
+    python3 solve_queue.py --stats            # show queue statistics
+    python3 solve_queue.py --cleanup          # remove solved/failed items from queue
 """
 
 import argparse
+import os
+import sys
 import time
-from solver import solve, _bits_to_board
-from solver_cache import solver_cache
-from solver_queue import solver_queue
+from multiprocessing import Process, cpu_count
+
+# Force unbuffered stdout so child process output appears immediately
+sys.stdout.reconfigure(line_buffering=True)
+
+
+def solve_item(item):
+    """Solve a single queue item. Runs in its own process."""
+    from solver import solve, _bits_to_board
+    from solver_cache import solver_cache
+    from solver_queue import solver_queue
+
+    bits = int(item['board_state'])
+    sc = int(item['stone_count'])
+    board = _bits_to_board(bits)
+
+    print(f"[pid {os.getpid()}] Solving state {bits} ({sc} stones)...", flush=True)
+    start = time.monotonic()
+    solution = solve(board, time_limit=None)
+    elapsed = time.monotonic() - start
+
+    if solution is not None and len(solution) > 0:
+        solver_cache.cache_solution_path(bits, solution, sc)
+        solver_queue.mark_solved(bits)
+        print(f"[pid {os.getpid()}] Solved {bits} in {elapsed:.1f}s — {len(solution)} moves cached.", flush=True)
+    else:
+        solver_cache.put_no_solution(bits, sc)
+        solver_queue.mark_failed(bits)
+        print(f"[pid {os.getpid()}] No solution for {bits} ({elapsed:.1f}s). Negative-cached.", flush=True)
+
+
+def solve_one():
+    """Claim and solve a single pending item. Returns True if an item was processed."""
+    from solver_queue import solver_queue
+
+    item = solver_queue.claim_next(include_solving=True)
+    if item is None:
+        print("No items in queue.", flush=True)
+        return False
+
+    solve_item(item)
+    return True
+
+
+def solve_all(num_workers):
+    """Solve all pending items using multiple worker processes."""
+    from solver_queue import solver_queue
+
+    # Grab all pending/solving items in one scan
+    items = solver_queue.get_all_claimable(include_solving=True)
+
+    if not items:
+        print("No items in queue.", flush=True)
+        return
+
+    print(f"Found {len(items)} item(s). Solving with {num_workers} worker(s)...\n", flush=True)
+
+    if num_workers == 1:
+        for item in items:
+            solve_item(item)
+    else:
+        # Process items in batches of num_workers
+        for i in range(0, len(items), num_workers):
+            batch = items[i:i + num_workers]
+            batch_num = i // num_workers + 1
+            total_batches = (len(items) + num_workers - 1) // num_workers
+            print(f"Batch {batch_num}/{total_batches}: launching {len(batch)} worker(s)...", flush=True)
+            procs = []
+            for item in batch:
+                p = Process(target=solve_item, args=(item,))
+                p.start()
+                procs.append(p)
+            for p in procs:
+                p.join()
+                if p.exitcode != 0:
+                    print(f"[pid {p.pid}] Worker exited with code {p.exitcode}", flush=True)
+
+    print(f"\nProcessed {len(items)} item(s).", flush=True)
 
 
 def show_stats():
+    from solver_queue import solver_queue
+
     stats = solver_queue.get_queue_stats()
     print("Solver Queue Statistics")
     print("-" * 30)
@@ -24,62 +105,31 @@ def show_stats():
     print(f"  {'total':>10}: {stats.get('total', 0)}")
 
 
-def solve_one():
-    """Claim and solve a single pending item. Returns True if an item was processed."""
-    item = solver_queue.claim_next(include_solving=True)
-    if item is None:
-        print("No items in queue.")
-        return False
-
-    bits = int(item['board_state'])
-    sc = int(item['stone_count'])
-    board = _bits_to_board(bits)
-
-    print(f"Solving state {bits} ({sc} stones)...", flush=True)
-    start = time.monotonic()
-    solution = solve(board, time_limit=None)
-    elapsed = time.monotonic() - start
-
-    if solution is not None and len(solution) > 0:
-        solver_cache.cache_solution_path(bits, solution, sc)
-        solver_queue.mark_solved(bits)
-        print(f"  Solved in {elapsed:.1f}s — {len(solution)} moves cached.")
-    else:
-        solver_cache.put_no_solution(bits, sc)
-        solver_queue.mark_failed(bits)
-        print(f"  No solution exists ({elapsed:.1f}s). Negative-cached.")
-
-    return True
-
-
-def solve_all():
-    """Solve all pending items in the queue."""
-    count = 0
-    while True:
-        if not solve_one():
-            break
-        count += 1
-    print(f"\nProcessed {count} item(s).")
-
-
 def main():
     parser = argparse.ArgumentParser(description="Solve queued board states.")
     parser.add_argument('--all', action='store_true', help='Solve all pending items')
+    parser.add_argument('--workers', type=int, default=1,
+                        help=f'Number of parallel workers (default: 1, max: {cpu_count()})')
     parser.add_argument('--stats', action='store_true', help='Show queue statistics')
     parser.add_argument('--cleanup', action='store_true', help='Remove solved/failed items from queue')
     args = parser.parse_args()
 
-    # Ensure tables exist
+    # Ensure tables exist (in main process)
+    print("Initializing...", flush=True)
+    from solver_cache import solver_cache
+    from solver_queue import solver_queue
     solver_cache.create_table_if_not_exists()
     solver_queue.create_table_if_not_exists()
+    print("Ready.\n", flush=True)
 
     if args.cleanup:
         count = solver_queue.cleanup_completed()
-        print(f"Removed {count} solved/failed item(s) from queue.")
+        print(f"Removed {count} solved/failed item(s) from queue.", flush=True)
     elif args.stats:
         show_stats()
     elif args.all:
-        solve_all()
+        num_workers = max(1, min(args.workers, cpu_count()))
+        solve_all(num_workers)
     else:
         solve_one()
 

--- a/solver.py
+++ b/solver.py
@@ -63,6 +63,15 @@ def _board_to_bits(board):
     return bits
 
 
+def _bits_to_board(bits):
+    """Convert a bitmask integer back to a 9x9 boolean board."""
+    board = [[False] * 9 for _ in range(9)]
+    for i, (r, c) in enumerate(VALID_CELLS):
+        if bits & (1 << i):
+            board[r][c] = True
+    return board
+
+
 def get_all_valid_moves(board):
     """Returns all legal moves as list of dicts."""
     moves = []
@@ -118,7 +127,8 @@ def solve(board, time_limit=5.0, progress_callback=None):
 
     failed = set()
     solution = []
-    deadline = time.monotonic() + time_limit
+    has_time_limit = time_limit is not None
+    deadline = time.monotonic() + time_limit if has_time_limit else 0
     moves_list = _PRECOMPUTED_MOVES
     check_interval = 0
     timed_out = False
@@ -131,14 +141,15 @@ def solve(board, time_limit=5.0, progress_callback=None):
             return True
 
         # Check time every 4096 calls to reduce overhead
-        check_interval += 1
-        if check_interval & 4095 == 0:
-            if time.monotonic() > deadline:
-                timed_out = True
-                return False
+        if has_time_limit:
+            check_interval += 1
+            if check_interval & 4095 == 0:
+                if time.monotonic() > deadline:
+                    timed_out = True
+                    return False
 
-        if timed_out:
-            return False
+            if timed_out:
+                return False
 
         if state in failed:
             return False

--- a/solver_queue.py
+++ b/solver_queue.py
@@ -1,0 +1,206 @@
+"""
+DynamoDB queue for board states that timed out during hint solving.
+
+States are enqueued when the solver times out, then picked up by a
+background worker (in-process daemon thread or the solve_queue.py CLI)
+and solved without a time limit.
+"""
+
+import boto3
+import os
+from datetime import datetime
+from botocore.exceptions import ClientError
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+class SolverQueue:
+    def __init__(self):
+        self.dynamodb = boto3.resource('dynamodb')
+        self.table_name = os.getenv('SOLVER_QUEUE_TABLE_NAME', 'skipping-stones-solver-queue')
+        self.table = self.dynamodb.Table(self.table_name)
+
+    def create_table_if_not_exists(self):
+        """Create the DynamoDB table if it doesn't exist."""
+        try:
+            self.table.load()
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                self.table = self.dynamodb.create_table(
+                    TableName=self.table_name,
+                    KeySchema=[
+                        {
+                            'AttributeName': 'board_state',
+                            'KeyType': 'HASH'
+                        }
+                    ],
+                    AttributeDefinitions=[
+                        {
+                            'AttributeName': 'board_state',
+                            'AttributeType': 'S'
+                        }
+                    ],
+                    BillingMode='PAY_PER_REQUEST'
+                )
+                self.table.meta.client.get_waiter('table_exists').wait(
+                    TableName=self.table_name
+                )
+            else:
+                raise e
+
+    def enqueue(self, board_bits: int, stone_count: int):
+        """Add a board state to the queue. Idempotent — only writes if the
+        item doesn't exist or is in pending/failed status."""
+        now = datetime.now().isoformat()
+        try:
+            self.table.put_item(
+                Item={
+                    'board_state': str(board_bits),
+                    'stone_count': stone_count,
+                    'status': 'pending',
+                    'created_at': now,
+                    'updated_at': now,
+                },
+                ConditionExpression='attribute_not_exists(board_state) OR #s IN (:pending, :failed)',
+                ExpressionAttributeNames={'#s': 'status'},
+                ExpressionAttributeValues={
+                    ':pending': 'pending',
+                    ':failed': 'failed',
+                },
+            )
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+                pass  # Already solving or solved — skip
+            else:
+                print(f"Solver queue enqueue error: {e}")
+
+    def claim_next(self, include_solving=False):
+        """Scan for the next item with the lowest stone_count and
+        atomically set its status to 'solving'. Returns the item dict or None.
+
+        If include_solving is True, also considers items already being solved
+        by another worker (useful for faster local CLI solving)."""
+        try:
+            if include_solving:
+                response = self.table.scan(
+                    FilterExpression='#s IN (:pending, :solving)',
+                    ExpressionAttributeNames={'#s': 'status'},
+                    ExpressionAttributeValues={
+                        ':pending': 'pending',
+                        ':solving': 'solving',
+                    },
+                )
+            else:
+                response = self.table.scan(
+                    FilterExpression='#s = :pending',
+                    ExpressionAttributeNames={'#s': 'status'},
+                    ExpressionAttributeValues={':pending': 'pending'},
+                )
+            items = response.get('Items', [])
+            if not items:
+                return None
+
+            # Sort by stone_count ascending (easier boards first),
+            # prefer pending over solving
+            items.sort(key=lambda x: (
+                0 if x.get('status') == 'pending' else 1,
+                int(x.get('stone_count', 999)),
+            ))
+            chosen = items[0]
+
+            # Atomically claim it (skip condition check for already-solving items)
+            if chosen.get('status') == 'solving':
+                # Already being solved — just return it without updating
+                return chosen
+
+            self.table.update_item(
+                Key={'board_state': chosen['board_state']},
+                UpdateExpression='SET #s = :solving, updated_at = :now',
+                ConditionExpression='#s = :pending',
+                ExpressionAttributeNames={'#s': 'status'},
+                ExpressionAttributeValues={
+                    ':solving': 'solving',
+                    ':pending': 'pending',
+                    ':now': datetime.now().isoformat(),
+                },
+            )
+            chosen['status'] = 'solving'
+            return chosen
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+                return None  # Someone else claimed it
+            print(f"Solver queue claim error: {e}")
+            return None
+        except Exception as e:
+            print(f"Solver queue claim error: {e}")
+            return None
+
+    def mark_solved(self, board_bits: int):
+        """Remove a solved item from the queue (result is in the solver cache)."""
+        try:
+            self.table.delete_item(Key={'board_state': str(board_bits)})
+        except Exception as e:
+            print(f"Solver queue mark_solved error: {e}")
+
+    def mark_failed(self, board_bits: int):
+        """Remove a failed item from the queue (negative result is in the solver cache)."""
+        try:
+            self.table.delete_item(Key={'board_state': str(board_bits)})
+        except Exception as e:
+            print(f"Solver queue mark_failed error: {e}")
+
+    def release(self, board_bits: int):
+        """Reset a queue item back to pending (e.g. after a worker crash)."""
+        try:
+            self.table.update_item(
+                Key={'board_state': str(board_bits)},
+                UpdateExpression='SET #s = :pending, updated_at = :now',
+                ExpressionAttributeNames={'#s': 'status'},
+                ExpressionAttributeValues={
+                    ':pending': 'pending',
+                    ':now': datetime.now().isoformat(),
+                },
+            )
+        except Exception as e:
+            print(f"Solver queue release error: {e}")
+
+    def cleanup_completed(self):
+        """Delete all solved and failed items from the queue. Returns count deleted."""
+        try:
+            response = self.table.scan(
+                FilterExpression='#s IN (:solved, :failed)',
+                ExpressionAttributeNames={'#s': 'status'},
+                ExpressionAttributeValues={
+                    ':solved': 'solved',
+                    ':failed': 'failed',
+                },
+            )
+            items = response.get('Items', [])
+            if not items:
+                return 0
+            with self.table.batch_writer() as batch:
+                for item in items:
+                    batch.delete_item(Key={'board_state': item['board_state']})
+            return len(items)
+        except Exception as e:
+            print(f"Solver queue cleanup error: {e}")
+            return 0
+
+    def get_queue_stats(self):
+        """Return counts by status."""
+        try:
+            response = self.table.scan()
+            items = response.get('Items', [])
+            stats = {'pending': 0, 'solving': 0, 'solved': 0, 'failed': 0}
+            for item in items:
+                status = item.get('status', 'unknown')
+                stats[status] = stats.get(status, 0) + 1
+            stats['total'] = len(items)
+            return stats
+        except Exception as e:
+            print(f"Solver queue stats error: {e}")
+            return {'pending': 0, 'solving': 0, 'solved': 0, 'failed': 0, 'total': 0}
+
+
+solver_queue = SolverQueue()

--- a/templates/skipping_stones.html
+++ b/templates/skipping_stones.html
@@ -1707,7 +1707,13 @@ class SkippingStonesGame {
                         } else {
                             this.hintsEnabled = false;
                             this.updateHintButtonState();
-                            if (msg.timed_out) {
+                            if (msg.no_solution) {
+                                this.showHintNotification('No solution exists from this position.', 'info');
+                            } else if (msg.queued && msg.timed_out) {
+                                this.showHintNotification('Solver timed out. Queued for background solving — check back later.', 'warning');
+                            } else if (msg.queued) {
+                                this.showHintNotification('Queued for background solving. Check back later.', 'info');
+                            } else if (msg.timed_out) {
                                 this.showHintNotification('Solver timed out.', 'warning');
                             } else {
                                 this.showHintNotification('No solution found from this position.', 'info');
@@ -1722,9 +1728,7 @@ class SkippingStonesGame {
             this.currentHint = null;
         } finally {
             if (requestId === this.hintRequestId) {
-                if (this.hintsEnabled) {
-                    hintBtn.innerHTML = '<i class="fas fa-lightbulb me-2"></i>Hint';
-                }
+                hintBtn.innerHTML = '<i class="fas fa-lightbulb me-2"></i>Hint';
                 this.renderBoard();
             }
         }


### PR DESCRIPTION
## Summary

- **Background solve queue**: When the hint solver times out (reduced from 60s to 10s), the board state is enqueued in a new DynamoDB table (`skipping-stones-solver-queue`) and solved asynchronously by a background worker thread with no time limit. Results are written to the solver cache for instant future hints.
- **Negative caching**: Definitively unsolvable states (exhaustive search) are cached with a `NO_SOLUTION` sentinel so repeat hint requests return immediately. Queued states are cached with a `QUEUED` sentinel to avoid re-running the 10s timeout.
- **CLI utility** (`solve_queue.py`): Local tool for manually solving queued states, with `--all`, `--stats`, and `--cleanup` flags.
- **Frontend**: Distinct user-facing messages for "no solution exists", "queued for background solving", and "timed out".

## Test plan

- [x] `python3 run_tests.py` — all existing tests pass
- [x] Start app, request hint on Level 7 (full board) — times out after 10s, shows "queued for background solving" notification, hint button resets
- [x] `python3 solve_queue.py --stats` — shows 1 pending item
- [x] `python3 solve_queue.py` — solves and caches the result
- [x] Request same hint again — instant cache hit
- [x] Request hint on an unsolvable position — shows "No solution exists" and caches negative result

🤖 Generated with [Claude Code](https://claude.com/claude-code)