### PR TITLE
Add diagonal move toggle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,15 +23,26 @@ python3 tests/test_compression.py
 
 # Deploy with Docker
 ./deploy.sh
+
+# Solve queue CLI (requires AWS credentials)
+python3 solve_queue.py           # solve one pending item
+python3 solve_queue.py --all     # solve all pending items
+python3 solve_queue.py --stats   # show queue statistics
 ```
 
 Tests use a custom runner (not pytest). Some tests (Google login, logout) require the Flask app running on localhost:5000. Compression tests run standalone.
 
 ## Architecture
 
-**Two-file backend:**
-- `app.py` — Flask app with all routes, Google OIDC auth flow (JWT verification against Google's public keys), Flask-Login session management, security headers middleware, and a share image generator (Pillow)
-- `database.py` — DynamoDB client wrapper (`db` singleton) with board/move compression utilities. Compression converts boolean boards to binary strings (`9x9:000...`) achieving 80-90% size reduction. Handles backward compatibility with old uncompressed JSON data.
+**Backend modules:**
+- `app.py` — Flask app with all routes, Google OIDC auth flow (JWT verification against Google's public keys), Flask-Login session management, security headers middleware, hint endpoint (calls solver), and a share image generator (Pillow)
+- `database.py` — DynamoDB client wrapper (`db` singleton) with board/move compression utilities. Compression converts boolean boards to binary strings (`9x9:000...`). Handles backward compatibility with old uncompressed JSON data.
+- `solver.py` — DFS backtracking peg solitaire solver using bitmask representation. The 9x9 board has 45 valid cells (cross shape, four 3x3 corners excluded); each state is a single integer bitmask. Precomputed move table and transposition table (set of failed states) for pruning. Configurable time limit (default 5s).
+- `solver_cache.py` — DynamoDB cache (`solver_cache` singleton) for solver solutions. Keyed by bitmask integer. Supports write-through caching of entire solution paths (every intermediate state along a solved path is also cached). Sentinel values: `"NO_SOLUTION"` (definitively unsolvable), `"QUEUED"` (pending background solve).
+- `solver_queue.py` — DynamoDB queue (`solver_queue` singleton) for board states that timed out. Items have status: pending → solving → solved/failed. Stale "solving" items auto-reset after 1 hour.
+- `solve_queue.py` — CLI utility for processing queued states with multiprocessing support.
+
+**Hint pipeline:** Player clicks Hint → `app.py` checks solver cache → on miss, runs `solver.solve()` with 10s limit → on timeout, enqueues to solver queue and returns "solving in background" → background worker (daemon thread in app or `solve_queue.py` CLI) solves without time limit → result cached for instant future hints.
 
 **Frontend (all in templates/):**
 - `skipping_stones.html` — Contains the entire game engine in vanilla JavaScript (~73KB). Handles board rendering, move validation, drag-and-drop, level selection, and state management via API calls.
@@ -41,12 +52,12 @@ Tests use a custom runner (not pytest). Some tests (Google login, logout) requir
 **Key design decisions:**
 - Authentication is optional — the game is fully playable without login; state saving requires auth
 - Single Gunicorn worker in production to avoid session sharing issues (server-side session state)
-- DynamoDB table auto-creates on first run if it doesn't exist
+- All three DynamoDB tables auto-create on first run if they don't exist
 - All game level configurations (7 levels: Cross, Triangle, Arrow, Diamond, Square, Full Board, etc.) are defined in `/api/skipping-stones/configs` endpoint in `app.py`
 
 ## Environment Variables
 
-Configured via `.env` file (see README.md for full list). Key vars: `SECRET_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, AWS credentials, `DYNAMODB_TABLE_NAME`.
+Configured via `.env` file (see README.md for full list). Key vars: `SECRET_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URI`, AWS credentials, `DYNAMODB_TABLE_NAME`, `SOLVER_CACHE_TABLE_NAME`, `SOLVER_QUEUE_TABLE_NAME`.
 
 ## API Structure
 
@@ -56,5 +67,6 @@ API endpoints under `/api/`:
 - `game-state/save`, `game-state/load`, `game-state/save-all-levels`, `game-state/load-all-levels`, `game-state/complete-level` — Game persistence
 - `auth/status`, `auth/logout`, `auth/refresh-session` — Auth management
 - `skipping-stones/configs` — Level configurations
+- `skipping-stones/hint` — Solver-powered hint (returns next move or status)
 - `user/stats` — User statistics
 - `share/level-completed` — Generates shareable PNG image

--- a/templates/skipping_stones.html
+++ b/templates/skipping_stones.html
@@ -100,6 +100,11 @@
                     <div id="shapeSelector" class="shape-selector d-flex flex-wrap gap-1">
                         <!-- Shape buttons loaded dynamically -->
                     </div>
+                    <div class="mt-2">
+                        <button id="diagonalBtn" class="btn btn-outline-secondary btn-sm" title="Allow diagonal jumps (D)">
+                            <i class="fas fa-arrows-alt me-1"></i>Diagonal Moves
+                        </button>
+                    </div>
                 </div>
             </div>
 
@@ -470,6 +475,7 @@ class SkippingStonesGame {
         this.hintsEnabled = false;
         this.currentHint = null;
         this.hintRequestId = 0;
+        this.allowDiagonals = false;
         this.init();
     }
 
@@ -684,6 +690,8 @@ class SkippingStonesGame {
             // Set up initial shape
             this._rebuildValidCellsSet();
             this.configurations = this.shapes[this.currentShape].levels;
+            this.allowDiagonals = this.shapes[this.currentShape].defaultDiagonals || false;
+            this.updateDiagonalButtonState();
             this.board = this.createBoard();
 
             this.renderShapeSelector();
@@ -714,6 +722,8 @@ class SkippingStonesGame {
         this.saveLevelState();
 
         this.currentShape = shapeId;
+        this.allowDiagonals = this.shapes[shapeId].defaultDiagonals || false;
+        this.updateDiagonalButtonState();
         this._rebuildValidCellsSet();
         this.configurations = this.shapes[shapeId].levels;
 
@@ -865,11 +875,14 @@ class SkippingStonesGame {
         document.getElementById('downloadShareBtn').onclick = () => this.downloadShareImage();
         document.getElementById('nativeShareBtn').onclick = () => this.nativeShare();
         document.getElementById('hintBtn').onclick = () => this.toggleHints();
+        document.getElementById('diagonalBtn').onclick = () => this.toggleDiagonals();
 
         document.addEventListener('keydown', (e) => {
-            if (e.key === 'h' && !e.ctrlKey && !e.metaKey && !e.altKey
-                && !e.target.closest('input, textarea, select')) {
+            if (e.ctrlKey || e.metaKey || e.altKey || e.target.closest('input, textarea, select')) return;
+            if (e.key === 'h') {
                 this.toggleHints();
+            } else if (e.key === 'd') {
+                this.toggleDiagonals();
             }
         });
     }
@@ -941,7 +954,9 @@ class SkippingStonesGame {
         const rowDiff = Math.abs(toRow - fromRow);
         const colDiff = Math.abs(toCol - fromCol);
 
-        if ((rowDiff === 2 && colDiff === 0) || (rowDiff === 0 && colDiff === 2)) {
+        const isOrthogonal = (rowDiff === 2 && colDiff === 0) || (rowDiff === 0 && colDiff === 2);
+        const isDiagonal = this.allowDiagonals && rowDiff === 2 && colDiff === 2;
+        if (isOrthogonal || isDiagonal) {
             const jumpRow = fromRow + (toRow - fromRow) / 2;
             const jumpCol = fromCol + (toCol - fromCol) / 2;
 
@@ -1026,7 +1041,10 @@ class SkippingStonesGame {
         for (let i = 0; i < rows; i++) {
             for (let j = 0; j < cols; j++) {
                 if (this.board[i] && this.board[i][j]) {
-                    const directions = [[-2, 0], [2, 0], [0, -2], [0, 2]];
+                    let directions = [[-2, 0], [2, 0], [0, -2], [0, 2]];
+                    if (this.allowDiagonals) {
+                        directions = directions.concat([[-2, -2], [-2, 2], [2, -2], [2, 2]]);
+                    }
                     for (const [dRow, dCol] of directions) {
                         const toRow = i + dRow;
                         const toCol = j + dCol;
@@ -1536,6 +1554,25 @@ class SkippingStonesGame {
         }
     }
 
+    toggleDiagonals() {
+        this.allowDiagonals = !this.allowDiagonals;
+        this.updateDiagonalButtonState();
+        this.cancelHintSolving();
+        this.updateDisplay();
+        this.saveLevelState();
+    }
+
+    updateDiagonalButtonState() {
+        const btn = document.getElementById('diagonalBtn');
+        if (this.allowDiagonals) {
+            btn.classList.remove('btn-outline-secondary');
+            btn.classList.add('btn-secondary');
+        } else {
+            btn.classList.remove('btn-secondary');
+            btn.classList.add('btn-outline-secondary');
+        }
+    }
+
     async fetchHint() {
         if (!this.hintsEnabled) return;
         const requestId = ++this.hintRequestId;
@@ -1547,7 +1584,7 @@ class SkippingStonesGame {
             const response = await fetch('/api/skipping-stones/hint', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ board: this.board, shape_id: this.currentShape })
+                body: JSON.stringify({ board: this.board, shape_id: this.currentShape, allow_diagonals: this.allowDiagonals })
             });
             if (requestId !== this.hintRequestId) return;
             if (!response.ok) {


### PR DESCRIPTION
## Summary
- Adds a diagonal move toggle button (keyboard shortcut: `D`) in the Board Shape card, allowing players to enable/disable diagonal jumps on any board shape
- Defaults to ON for the Diamond shape and OFF for all others; resets to shape default when switching shapes
- Threads `allow_diagonals` through the full stack: solver engine, solver cache (with `diag:` key prefix for cache differentiation), solver queue, CLI worker, hint endpoint, and background solver

## Test plan
- [x] `python3 run_tests.py` — all 4 tests pass
- [x] Start app, verify Wiegleb: diagonal toggle OFF, only orthogonal moves highlighted
- [ ] Toggle diagonals ON: diagonal destinations appear as valid moves, diagonal jumps work
- [ ] Switch to Diamond shape: toggle auto-enables
- [ ] Switch back to Wiegleb: toggle auto-disables
- [ ] Test hints with diagonals enabled/disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)