### PR TITLE
Warm aesthetic refresh and persistent diagonal toggle

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -9,29 +9,226 @@
     <title>{% block title %}Skipping Stones{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Nunito:wght@400;600;700&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --bg-warm-1: #f5efe4;
+            --bg-warm-2: #ece3d2;
+            --surface: #fbf7ef;
+            --surface-2: #f1ead9;
+            --ink: #3d3730;
+            --ink-soft: #6b6358;
+            --line: #d9cfbc;
+
+            --stone: #7a8089;
+            --stone-hi: #aab0b7;
+            --stone-lo: #4e545c;
+            --stone-selected: #8fa68e;
+            --stone-valid: #d9b38a;
+            --stone-hint: #c97b63;
+
+            --accent: #8fa68e;
+            --accent-deep: #6f8770;
+            --accent-warm: #c97b63;
+            --accent-warm-deep: #a85f48;
+
+            --shadow-soft: 0 1px 2px rgba(61,55,48,.06), 0 8px 24px rgba(61,55,48,.08);
+            --shadow-stone: inset 0 2px 3px rgba(255,255,255,.35),
+                            inset 0 -3px 4px rgba(0,0,0,.18),
+                            0 2px 3px rgba(61,55,48,.18);
+            --radius-lg: 18px;
+            --radius-md: 12px;
+            --radius-pill: 999px;
+        }
         body {
-            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background:
+                radial-gradient(1200px 800px at 20% 0%, #fff8ec 0%, rgba(255,248,236,0) 60%),
+                linear-gradient(180deg, var(--bg-warm-1), var(--bg-warm-2));
+            background-attachment: fixed;
             min-height: 100vh;
             display: flex;
             flex-direction: column;
+            font-family: 'Nunito', system-ui, -apple-system, sans-serif;
+            color: var(--ink);
+        }
+        h1, h2, h3, h4, h5, h6, .navbar-brand {
+            font-family: 'Fraunces', Georgia, serif;
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            color: var(--ink);
         }
         .navbar {
-            background: rgba(255, 255, 255, 0.1) !important;
-            backdrop-filter: blur(10px);
+            background: rgba(251, 247, 239, 0.88) !important;
+            backdrop-filter: blur(8px);
+            border-bottom: 1px solid var(--line);
+        }
+        .navbar .navbar-brand,
+        .navbar .nav-link,
+        .navbar .text-light,
+        .navbar .dropdown-toggle {
+            color: var(--ink) !important;
+        }
+        .navbar .user-info span {
+            color: var(--ink) !important;
         }
         .card {
-            background: rgba(255, 255, 255, 0.9);
-            backdrop-filter: blur(10px);
-            border: none;
-            border-radius: 15px;
-            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            background: var(--surface);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow-soft);
+            color: var(--ink);
         }
+        .card-header {
+            background: transparent !important;
+            border-bottom: 1px solid var(--line);
+            color: var(--ink) !important;
+            font-family: 'Fraunces', Georgia, serif;
+        }
+        .card-header.bg-primary,
+        .card-header.bg-success,
+        .card-header.bg-info,
+        .card-header.bg-dark,
+        .card-header.bg-warning {
+            background: transparent !important;
+            color: var(--ink) !important;
+        }
+        .card-header h3, .card-header h5, .card-header h6 { color: var(--ink); }
+        .card.bg-light { background: var(--surface-2) !important; border-color: var(--line); }
 
         .alert {
-            border-radius: 10px;
-            border: none;
+            border-radius: var(--radius-md);
+            border: 1px solid var(--line);
+            background: var(--surface);
+            color: var(--ink);
         }
+        .alert-danger { border-left: 4px solid var(--accent-warm-deep); }
+        .alert-success { border-left: 4px solid var(--accent-deep); }
+        .alert-info { border-left: 4px solid var(--accent); }
+
+        .text-primary { color: var(--accent-deep) !important; }
+        .text-success { color: var(--accent-deep) !important; }
+        .text-info { color: var(--accent) !important; }
+        .text-warning { color: var(--accent-warm) !important; }
+        .text-muted { color: var(--ink-soft) !important; }
+        .text-secondary { color: var(--ink-soft) !important; }
+
+        /* Warm button overrides */
+        .btn {
+            border-radius: var(--radius-pill);
+            font-weight: 600;
+            transition: all 0.25s ease;
+            border-width: 1.5px;
+        }
+        .btn-primary {
+            background: var(--accent);
+            border-color: var(--accent);
+            color: #fbf7ef;
+        }
+        .btn-primary:hover, .btn-primary:focus {
+            background: var(--accent-deep);
+            border-color: var(--accent-deep);
+            color: #fbf7ef;
+            box-shadow: var(--shadow-soft);
+        }
+        .btn-success {
+            background: var(--accent-deep);
+            border-color: var(--accent-deep);
+            color: #fbf7ef;
+        }
+        .btn-success:hover, .btn-success:focus {
+            background: #5f7560;
+            border-color: #5f7560;
+            color: #fbf7ef;
+        }
+        .btn-warning {
+            background: var(--stone-valid);
+            border-color: var(--stone-valid);
+            color: var(--ink);
+        }
+        .btn-warning:hover, .btn-warning:focus {
+            background: #c49b6b;
+            border-color: #c49b6b;
+            color: var(--ink);
+        }
+        .btn-info {
+            background: var(--accent-warm);
+            border-color: var(--accent-warm);
+            color: #fbf7ef;
+        }
+        .btn-info:hover, .btn-info:focus {
+            background: var(--accent-warm-deep);
+            border-color: var(--accent-warm-deep);
+            color: #fbf7ef;
+        }
+        .btn-secondary {
+            background: var(--surface);
+            border-color: var(--line);
+            color: var(--ink-soft);
+        }
+        .btn-secondary:hover, .btn-secondary:focus {
+            background: var(--surface-2);
+            border-color: var(--ink-soft);
+            color: var(--ink);
+        }
+        .btn-outline-info {
+            background: transparent;
+            border-color: var(--accent-warm);
+            color: var(--accent-warm-deep);
+        }
+        .btn-outline-info:hover, .btn-outline-info:focus {
+            background: var(--accent-warm);
+            border-color: var(--accent-warm);
+            color: #fbf7ef;
+        }
+        .btn-outline-secondary {
+            background: transparent;
+            border-color: var(--line);
+            color: var(--ink-soft);
+        }
+        .btn-outline-secondary:hover, .btn-outline-secondary:focus {
+            background: var(--surface-2);
+            border-color: var(--ink-soft);
+            color: var(--ink);
+        }
+        .btn-outline-secondary.active,
+        .btn-outline-secondary:active {
+            background: var(--accent) !important;
+            border-color: var(--accent) !important;
+            color: #fbf7ef !important;
+        }
+        .btn-outline-light {
+            background: transparent;
+            border-color: var(--line);
+            color: var(--ink);
+        }
+        .btn-outline-light:hover, .btn-outline-light:focus {
+            background: var(--surface-2);
+            border-color: var(--ink-soft);
+            color: var(--ink);
+        }
+        .btn:hover:not(:disabled) { box-shadow: var(--shadow-soft); }
+
+        .progress { background: var(--surface-2); border-radius: var(--radius-pill); height: 10px; }
+        .progress-bar { background: var(--accent) !important; }
+
+        .dropdown-menu {
+            background: var(--surface);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-md);
+            box-shadow: var(--shadow-soft);
+        }
+        .dropdown-item { color: var(--ink); }
+        .dropdown-item:hover { background: var(--surface-2); color: var(--ink); }
+
+        .modal-content {
+            background: var(--surface);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-lg);
+            color: var(--ink);
+        }
+        .modal-header, .modal-footer { border-color: var(--line); }
         
         .user-info {
             display: flex;
@@ -51,21 +248,23 @@
         }
 
         .footer {
-            background: rgba(255, 255, 255, 0.1);
-            backdrop-filter: blur(10px);
+            background: rgba(251, 247, 239, 0.88);
+            backdrop-filter: blur(8px);
+            border-top: 1px solid var(--line);
             padding: 1rem 0;
             margin-top: auto;
             text-align: center;
+            color: var(--ink-soft);
         }
 
         .footer a {
-            color: rgba(255, 255, 255, 0.8);
+            color: var(--ink-soft);
             text-decoration: none;
             transition: color 0.3s ease;
         }
 
         .footer a:hover {
-            color: white;
+            color: var(--accent-deep);
         }
 
         .footer-content {
@@ -82,14 +281,15 @@
         }
 
         .privacy-notice {
-            background: rgba(255, 255, 255, 0.1);
-            border-radius: 8px;
+            background: var(--surface-2);
+            border-radius: var(--radius-md);
             padding: 0.75rem 1rem;
             margin-top: 0.5rem;
             font-size: 0.9rem;
             max-width: 600px;
             text-align: center;
-            border-left: 3px solid rgba(255, 255, 255, 0.3);
+            border-left: 3px solid var(--accent);
+            color: var(--ink-soft);
         }
 
         .privacy-notice i {
@@ -97,66 +297,34 @@
             opacity: 0.8;
         }
 
-        /* Google Login Button Styling */
+        /* Google Login Button — calm warm style */
         .google-login-btn {
-            background: linear-gradient(135deg, #4285f4, #34a853, #fbbc05, #ea4335) !important;
-            background-size: 300% 300% !important;
-            animation: google-gradient 3s ease infinite !important;
-            color: white !important;
-            border-radius: 25px !important;
-            padding: 10px 24px !important;
-            font-weight: 700 !important;
+            background: var(--surface) !important;
+            color: var(--ink) !important;
+            border-radius: var(--radius-pill) !important;
+            padding: 8px 20px !important;
+            font-weight: 600 !important;
             text-decoration: none !important;
-            transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) !important;
-            box-shadow: 0 6px 20px rgba(66, 133, 244, 0.5), 0 0 20px rgba(251, 188, 5, 0.3) !important;
-            border: 2px solid rgba(255, 255, 255, 0.4) !important;
-            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) !important;
-            position: relative !important;
-            overflow: hidden !important;
-        }
-
-        .google-login-btn::before {
-            content: '' !important;
-            position: absolute !important;
-            top: 0 !important;
-            left: -100% !important;
-            width: 100% !important;
-            height: 100% !important;
-            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent) !important;
-            transition: left 0.6s ease !important;
+            transition: all 0.25s ease !important;
+            box-shadow: var(--shadow-soft) !important;
+            border: 1.5px solid var(--line) !important;
         }
 
         .google-login-btn:hover {
-            transform: translateY(-3px) scale(1.05) !important;
-            box-shadow: 0 10px 30px rgba(66, 133, 244, 0.7), 0 0 30px rgba(251, 188, 5, 0.5) !important;
-            color: white !important;
+            background: var(--surface-2) !important;
+            color: var(--ink) !important;
+            border-color: var(--ink-soft) !important;
             text-decoration: none !important;
-            background-size: 200% 200% !important;
-            border-color: rgba(255, 255, 255, 0.6) !important;
-        }
-
-        .google-login-btn:hover::before {
-            left: 100% !important;
+            transform: translateY(-1px);
         }
 
         .google-login-btn:active {
-            transform: translateY(-1px) scale(1.02) !important;
-            box-shadow: 0 4px 15px rgba(66, 133, 244, 0.6) !important;
-        }
-
-        @keyframes google-gradient {
-            0% { background-position: 0% 50%; }
-            25% { background-position: 100% 50%; }
-            50% { background-position: 100% 100%; }
-            75% { background-position: 0% 100%; }
-            100% { background-position: 0% 50%; }
+            transform: translateY(0);
         }
 
         .google-login-btn .fab.fa-google {
-            color: white !important;
-            font-size: 1.2em !important;
-            text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) !important;
-            filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3)) !important;
+            color: var(--accent-warm-deep) !important;
+            font-size: 1.1em !important;
         }
 
         @media (max-width: 768px) {

--- a/templates/skipping_stones.html
+++ b/templates/skipping_stones.html
@@ -100,9 +100,15 @@
                     <div id="shapeSelector" class="shape-selector d-flex flex-wrap gap-1">
                         <!-- Shape buttons loaded dynamically -->
                     </div>
-                    <div class="mt-2">
-                        <button id="diagonalBtn" class="btn btn-outline-secondary btn-sm" title="Allow diagonal jumps (D)">
-                            <i class="fas fa-arrows-alt me-1"></i>Diagonal Moves
+                    <div class="diagonal-toggle-row mt-3">
+                        <button id="diagonalBtn" class="diagonal-toggle" role="switch" aria-checked="false" title="Allow diagonal jumps (D)">
+                            <span class="diagonal-toggle-label">
+                                <i class="fas fa-arrows-alt me-1"></i>Diagonal moves
+                            </span>
+                            <span class="diagonal-toggle-track" aria-hidden="true">
+                                <span class="diagonal-toggle-thumb"></span>
+                            </span>
+                            <span class="diagonal-toggle-state">OFF</span>
                         </button>
                     </div>
                 </div>
@@ -206,24 +212,29 @@
 }
 
 .level-badge {
-    background: linear-gradient(135deg, #007bff, #0056b3);
-    color: white;
-    padding: 10px 20px;
-    border-radius: 25px;
-    font-weight: bold;
-    font-size: 1.2em;
-    box-shadow: 0 4px 12px rgba(0, 123, 255, 0.4);
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    color: #fbf7ef;
+    padding: 10px 22px;
+    border-radius: var(--radius-pill);
+    font-family: 'Fraunces', Georgia, serif;
+    font-weight: 600;
+    font-size: 1.15em;
+    letter-spacing: 0.01em;
+    box-shadow: 0 2px 8px rgba(143, 166, 142, 0.35);
     display: inline-block;
-    border: 2px solid rgba(255, 255, 255, 0.3);
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+    border: 1px solid rgba(255, 255, 255, 0.4);
 }
 
 .game-board {
     display: grid;
     gap: 2px;
-    background: #ddd;
-    padding: 10px;
-    border-radius: 8px;
+    background: var(--surface-2);
+    padding: 16px;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--line);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
+                0 1px 2px rgba(61, 55, 48, 0.06),
+                0 8px 24px rgba(61, 55, 48, 0.06);
     max-width: 500px;
     width: 100%;
     margin: 0 auto;
@@ -231,131 +242,272 @@
 
 .cell {
     aspect-ratio: 1;
-    border: 1px solid #999;
+    border: none;
     display: flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    transition: all 0.2s;
-    background: #f8f9fa;
+    transition: transform 0.25s ease;
+    background: transparent;
+    border-radius: 50%;
     font-size: clamp(0.6em, 2.5vw, 1em);
+    color: transparent;
+    position: relative;
 }
 
-.cell:hover {
-    background: #e9ecef;
+.cell::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 60%;
+    height: 60%;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle at 50% 45%, rgba(61, 55, 48, 0.18) 0%, rgba(61, 55, 48, 0.08) 55%, transparent 80%);
+    box-shadow: inset 0 2px 3px rgba(61, 55, 48, 0.22),
+                inset 0 -1px 1px rgba(255, 255, 255, 0.55);
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.cell:hover::before {
+    background: radial-gradient(circle at 50% 45%, rgba(61, 55, 48, 0.24) 0%, rgba(61, 55, 48, 0.1) 55%, transparent 80%);
+}
+
+.cell.marble::before,
+.cell.hint-source::before {
+    display: none;
 }
 
 .cell.marble {
-    background: #007bff;
+    background: transparent;
+    color: transparent;
+}
+.cell.marble::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 82%;
+    aspect-ratio: 1;
+    transform: translate(-50%, -50%);
     border-radius: 50%;
-    color: white;
-    font-weight: bold;
+    background: radial-gradient(circle at 35% 28%, var(--stone-hi) 0%, var(--stone) 45%, var(--stone-lo) 100%);
+    box-shadow: var(--shadow-stone);
+    pointer-events: none;
+}
+.cell.marble:hover::after {
+    background: radial-gradient(circle at 35% 28%, #bac0c7 0%, #858b94 45%, var(--stone-lo) 100%);
 }
 
-.cell.selected {
-    background: #28a745;
-    border: 2px solid #20c997;
-    animation: selected-pulse 1.5s ease-in-out infinite;
+.cell.selected::after {
+    background: radial-gradient(circle at 35% 28%, #c4d1bf 0%, var(--stone-selected) 50%, #5f7560 100%);
+    box-shadow: var(--shadow-stone), 0 0 0 3px rgba(143, 166, 142, 0.35);
+    animation: selected-pulse 2s ease-in-out infinite;
 }
 
 @keyframes selected-pulse {
     0%, 100% {
-        transform: scale(1);
-        box-shadow: 0 0 4px rgba(40, 167, 69, 0.4);
+        box-shadow: var(--shadow-stone), 0 0 0 3px rgba(143, 166, 142, 0.3);
     }
     50% {
-        transform: scale(1.08);
-        box-shadow: 0 0 12px rgba(40, 167, 69, 0.7);
+        box-shadow: var(--shadow-stone), 0 0 0 6px rgba(143, 166, 142, 0.45);
     }
 }
 
 .cell.valid-move {
-    background: #ffc107;
-    border: 2px solid #fd7e14;
+    background: transparent;
+    border: none;
+}
+.cell.valid-move::before {
+    background: radial-gradient(circle at 50% 45%, rgba(217, 179, 138, 0.85) 0%, rgba(217, 179, 138, 0.45) 55%, transparent 80%);
+    box-shadow: inset 0 2px 3px rgba(168, 120, 72, 0.35),
+                inset 0 -1px 1px rgba(255, 255, 255, 0.55),
+                0 0 0 2px rgba(217, 179, 138, 0.35);
 }
 
 .cell.invalid {
-    background-color: #6c757d !important;
-    cursor: not-allowed !important;
-    opacity: 0.6 !important;
-    border-color: #495057 !important;
+    background-color: transparent !important;
+    cursor: default !important;
+    opacity: 0 !important;
+    pointer-events: none;
 }
 
 .cell.hint-source {
-    background: #e83e8c !important;
-    border: 2px solid #c2185b !important;
-    animation: hint-pulse 1.5s ease-in-out infinite;
+    background: transparent !important;
+}
+.cell.hint-source::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 82%;
+    aspect-ratio: 1;
+    transform: translate(-50%, -50%);
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 28%, #e9b0a0 0%, var(--accent-warm) 50%, var(--accent-warm-deep) 100%);
+    box-shadow: var(--shadow-stone), 0 0 0 3px rgba(201, 123, 99, 0.35);
+    animation: hint-pulse 2.2s ease-in-out infinite;
+    pointer-events: none;
 }
 
 .cell.hint-destination {
-    background: #f8f9fa;
-    border: 3px dashed #e83e8c !important;
-    animation: hint-pulse 1.5s ease-in-out infinite;
+    background: transparent !important;
+    border: none !important;
+}
+.cell.hint-destination::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 70%;
+    aspect-ratio: 1;
+    transform: translate(-50%, -50%);
+    border: 2.5px dashed var(--accent-warm);
+    border-radius: 50%;
+    animation: hint-pulse 2.2s ease-in-out infinite;
+    pointer-events: none;
 }
 
 @keyframes hint-pulse {
-    0%, 100% {
-        transform: scale(1);
-        box-shadow: 0 0 4px rgba(232, 62, 140, 0.4);
-    }
-    50% {
-        transform: scale(1.08);
-        box-shadow: 0 0 12px rgba(232, 62, 140, 0.7);
-    }
+    0%, 100% { opacity: 0.85; }
+    50% { opacity: 1; }
 }
 
 .shape-selector .shape-btn {
     padding: 6px 14px;
-    border: 2px solid #dee2e6;
-    border-radius: 20px;
+    border: 1.5px solid var(--line);
+    border-radius: var(--radius-pill);
     cursor: pointer;
-    transition: all 0.2s;
-    background: #f8f9fa;
+    transition: all 0.25s ease;
+    background: var(--surface);
+    color: var(--ink-soft);
     font-size: 0.85em;
-    font-weight: 500;
+    font-weight: 600;
 }
 
 .shape-selector .shape-btn:hover {
-    border-color: #007bff;
-    background: #e7f1ff;
+    border-color: var(--accent);
+    background: var(--surface-2);
+    color: var(--ink);
 }
 
 .shape-selector .shape-btn.active {
-    background: #343a40;
-    color: white;
-    border-color: #343a40;
+    background: var(--ink);
+    color: var(--surface);
+    border-color: var(--ink);
+}
+
+.diagonal-toggle-row {
+    display: flex;
+    justify-content: flex-start;
+    padding: 2px 4px 0;
+}
+.diagonal-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 12px;
+    background: var(--surface);
+    border: 1.5px solid var(--line);
+    border-radius: var(--radius-pill);
+    color: var(--ink-soft);
+    font-size: 0.85em;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    font-family: inherit;
+}
+.diagonal-toggle:hover {
+    background: var(--surface-2);
+    border-color: var(--ink-soft);
+    color: var(--ink);
+}
+.diagonal-toggle-label {
+    flex: 1;
+    text-align: left;
+    white-space: nowrap;
+}
+.diagonal-toggle-track {
+    position: relative;
+    display: inline-block;
+    width: 34px;
+    height: 18px;
+    background: var(--line);
+    border-radius: 999px;
+    transition: background 0.25s ease;
+    flex-shrink: 0;
+}
+.diagonal-toggle-thumb {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 14px;
+    height: 14px;
+    background: var(--surface);
+    border-radius: 50%;
+    box-shadow: 0 1px 2px rgba(61, 55, 48, 0.25);
+    transition: left 0.25s ease, background 0.25s ease;
+}
+.diagonal-toggle-state {
+    font-size: 0.72em;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--ink-soft);
+    min-width: 26px;
+    text-align: right;
+}
+.diagonal-toggle.on {
+    background: #f0f4ed;
+    border-color: var(--accent);
+    color: var(--ink);
+}
+.diagonal-toggle.on .diagonal-toggle-track {
+    background: var(--accent);
+}
+.diagonal-toggle.on .diagonal-toggle-thumb {
+    left: 18px;
+    background: #fbf7ef;
+}
+.diagonal-toggle.on .diagonal-toggle-state {
+    color: var(--accent-deep);
 }
 
 .config-item {
-    padding: 10px;
-    margin: 5px 0;
-    border: 1px solid #dee2e6;
-    border-radius: 5px;
+    padding: 10px 12px;
+    margin: 6px 0;
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--line);
+    border-radius: var(--radius-md);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: all 0.25s ease;
+    background: var(--surface);
+    color: var(--ink);
 }
 
 .config-item:hover {
-    background: #f8f9fa;
-    border-color: #007bff;
+    background: var(--surface-2);
+    border-left-color: var(--accent);
 }
 
 .config-item.active {
-    background: #007bff;
-    color: white;
-    border-color: #0056b3;
-    box-shadow: 0 2px 8px rgba(0, 123, 255, 0.3);
-    transform: translateY(-1px);
+    background: var(--surface-2);
+    color: var(--ink);
+    border-color: var(--line);
+    border-left: 3px solid var(--accent-deep);
+    box-shadow: var(--shadow-soft);
 }
 
 .config-item.completed {
-    border-color: #28a745;
-    background: #f8fff9;
+    border-left: 3px solid var(--accent);
+    background: #f3f0e3;
 }
 
 .config-item.completed:hover {
-    background: #e8f5e8;
-    border-color: #20c997;
+    background: #ede8d6;
+    border-left-color: var(--accent-deep);
 }
 
 .move-history {
@@ -364,11 +516,12 @@
 }
 
 .move-item {
-    padding: 5px;
-    margin: 2px 0;
-    background: #f8f9fa;
-    border-radius: 3px;
+    padding: 6px 8px;
+    margin: 3px 0;
+    background: var(--surface-2);
+    border-radius: var(--radius-md);
     font-size: 0.9em;
+    color: var(--ink);
 }
 
 @media (max-width: 768px) {
@@ -378,77 +531,30 @@
 }
 
 .btn:disabled {
-    opacity: 0.6;
+    opacity: 0.5;
     cursor: not-allowed;
 }
 
-/* Game Board Login Button Styling */
+/* Game Board Login Button — calm warm style */
 .google-login-game-btn {
-    background: linear-gradient(135deg, #007bff, #0056b3) !important;
-    background-size: 200% 200% !important;
-    animation: blue-gradient-game 3s ease infinite !important;
-    color: white !important;
-    border: none !important;
-    box-shadow: 0 6px 20px rgba(0, 123, 255, 0.5) !important;
-    transition: all 0.4s cubic-bezier(0.175, 0.885, 0.32, 1.275) !important;
-    position: relative !important;
-    overflow: hidden !important;
+    background: var(--accent) !important;
+    color: #fbf7ef !important;
+    border: 1.5px solid var(--accent) !important;
+    border-radius: var(--radius-pill) !important;
+    box-shadow: var(--shadow-soft) !important;
+    transition: all 0.25s ease !important;
     font-weight: 600 !important;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.4) !important;
-}
-
-.google-login-game-btn::before {
-    content: '' !important;
-    position: absolute !important;
-    top: 0 !important;
-    left: -100% !important;
-    width: 100% !important;
-    height: 100% !important;
-    background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.3), transparent) !important;
-    transition: left 0.6s ease !important;
 }
 
 .google-login-game-btn:hover {
-    transform: translateY(-2px) scale(1.03) !important;
-    box-shadow: 0 10px 30px rgba(0, 123, 255, 0.7) !important;
-    background-size: 150% 150% !important;
-}
-
-.google-login-game-btn:hover::before {
-    left: 100% !important;
-}
-
-.google-login-game-btn:active {
-    transform: translateY(0) scale(1.01) !important;
-    box-shadow: 0 4px 15px rgba(0, 123, 255, 0.6) !important;
-}
-
-@keyframes blue-gradient-game {
-    0% { background-position: 0% 50%; }
-    50% { background-position: 100% 50%; }
-    100% { background-position: 0% 50%; }
+    background: var(--accent-deep) !important;
+    border-color: var(--accent-deep) !important;
+    transform: translateY(-1px) !important;
 }
 
 .google-login-game-btn .fab.fa-google {
-    background: linear-gradient(135deg, #4285f4, #34a853, #fbbc05, #ea4335) !important;
-    background-size: 200% 200% !important;
-    -webkit-background-clip: text !important;
-    -webkit-text-fill-color: transparent !important;
-    background-clip: text !important;
-    animation: google-icon-pulse 2s ease-in-out infinite !important;
-    font-size: 1.1em !important;
-    filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.3)) !important;
-}
-
-@keyframes google-icon-pulse {
-    0%, 100% {
-        background-size: 200% 200%;
-        transform: scale(1);
-    }
-    50% {
-        background-size: 150% 150%;
-        transform: scale(1.1);
-    }
+    color: #fbf7ef !important;
+    font-size: 1.05em !important;
 }
 </style>
 
@@ -476,6 +582,7 @@ class SkippingStonesGame {
         this.currentHint = null;
         this.hintRequestId = 0;
         this.allowDiagonals = false;
+        this.diagonalsByShape = {};
         this.init();
     }
 
@@ -507,6 +614,7 @@ class SkippingStonesGame {
         const sessionData = {
             levelStates: this.levelStates,
             currentShape: this.currentShape,
+            diagonalsByShape: this.diagonalsByShape,
             timestamp: Date.now(),
             userEmail: this.userEmail || 'anonymous'
         };
@@ -649,6 +757,9 @@ class SkippingStonesGame {
                             this.clearSessionStorage();
                         } else {
                             this.levelStates = sessionData.levelStates || {};
+                            if (sessionData.diagonalsByShape) {
+                                this.diagonalsByShape = sessionData.diagonalsByShape;
+                            }
                             // Restore shape from session
                             if (sessionData.currentShape && this.shapes[sessionData.currentShape]) {
                                 this.currentShape = sessionData.currentShape;
@@ -657,6 +768,8 @@ class SkippingStonesGame {
                                 this.renderShapeSelector();
                                 this.renderConfigurations();
                             }
+                            this.allowDiagonals = this._getShapeDiagonalPreference(this.currentShape);
+                            this.updateDiagonalButtonState();
                         }
                     } catch (error) {
                         console.error('Error loading level states:', error);
@@ -690,7 +803,7 @@ class SkippingStonesGame {
             // Set up initial shape
             this._rebuildValidCellsSet();
             this.configurations = this.shapes[this.currentShape].levels;
-            this.allowDiagonals = this.shapes[this.currentShape].defaultDiagonals || false;
+            this.allowDiagonals = this._getShapeDiagonalPreference(this.currentShape);
             this.updateDiagonalButtonState();
             this.board = this.createBoard();
 
@@ -722,7 +835,7 @@ class SkippingStonesGame {
         this.saveLevelState();
 
         this.currentShape = shapeId;
-        this.allowDiagonals = this.shapes[shapeId].defaultDiagonals || false;
+        this.allowDiagonals = this._getShapeDiagonalPreference(shapeId);
         this.updateDiagonalButtonState();
         this._rebuildValidCellsSet();
         this.configurations = this.shapes[shapeId].levels;
@@ -1261,6 +1374,7 @@ class SkippingStonesGame {
                 completedLevels: this.completedLevels,
                 currentConfig: this.currentConfig,
                 currentShape: this.currentShape,
+                diagonalsByShape: this.diagonalsByShape,
                 board: this.board,
                 moveHistory: this.moveHistory,
                 timestamp: Date.now()
@@ -1285,6 +1399,9 @@ class SkippingStonesGame {
                     this.currentConfig = gameState.currentConfig || 'level1';
                     this.board = gameState.board || [];
                     this.moveHistory = gameState.moveHistory || [];
+                    if (gameState.diagonalsByShape) {
+                        this.diagonalsByShape = gameState.diagonalsByShape;
+                    }
 
                     // Restore shape
                     if (gameState.currentShape && this.shapes[gameState.currentShape]) {
@@ -1294,6 +1411,8 @@ class SkippingStonesGame {
                         this.renderShapeSelector();
                         this.renderConfigurations();
                     }
+                    this.allowDiagonals = this._getShapeDiagonalPreference(this.currentShape);
+                    this.updateDiagonalButtonState();
 
                     console.log('Restored game state from localStorage backup');
                     this.updateDisplay();
@@ -1556,20 +1675,32 @@ class SkippingStonesGame {
 
     toggleDiagonals() {
         this.allowDiagonals = !this.allowDiagonals;
+        this.diagonalsByShape[this.currentShape] = this.allowDiagonals;
         this.updateDiagonalButtonState();
         this.cancelHintSolving();
         this.updateDisplay();
         this.saveLevelState();
     }
 
+    _getShapeDiagonalPreference(shapeId) {
+        if (Object.prototype.hasOwnProperty.call(this.diagonalsByShape, shapeId)) {
+            return this.diagonalsByShape[shapeId];
+        }
+        return this.shapes[shapeId].defaultDiagonals || false;
+    }
+
     updateDiagonalButtonState() {
         const btn = document.getElementById('diagonalBtn');
+        if (!btn) return;
+        const stateEl = btn.querySelector('.diagonal-toggle-state');
         if (this.allowDiagonals) {
-            btn.classList.remove('btn-outline-secondary');
-            btn.classList.add('btn-secondary');
+            btn.classList.add('on');
+            btn.setAttribute('aria-checked', 'true');
+            if (stateEl) stateEl.textContent = 'ON';
         } else {
-            btn.classList.remove('btn-secondary');
-            btn.classList.add('btn-outline-secondary');
+            btn.classList.remove('on');
+            btn.setAttribute('aria-checked', 'false');
+            if (stateEl) stateEl.textContent = 'OFF';
         }
     }
 


### PR DESCRIPTION
Replace the cool purple/glass theme with a warm cream & river-stone palette: Nunito/Fraunces typography, soft shadows, pebble-style stones rendered via a square ::after pseudo-element (fixes ovals on large boards), subtle inset dimples for empty positions, and warm Bootstrap button overrides. Rework the diagonal moves control as a clearly labeled switch grouped with the board shape selector, and persist the user's choice per shape via sessionStorage and the localStorage backup so it survives moves, level switches, and reloads.